### PR TITLE
Add SVG hero banner and badge masthead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/llama3-emotion-lora/main/docs/banner.svg" alt="llama3-emotion-lora — six-class emotion text classification (joy, sadness, anger, fear, love, surprise) with Llama3-8B + LoRA + FlashAttention; 92.62% accuracy, beating BERT and RoBERTa baselines." width="880">
+</p>
 
-# Emotion Text Classification Using Llama3-8b and LoRA
+<div align="center">
+
+[![Model](https://img.shields.io/badge/Model-Llama3--8B-7c3aed)](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
+[![Built on](https://img.shields.io/badge/built%20on-LLaMA--Factory-blue)](https://github.com/hiyouga/LLaMA-Factory)
+![Accuracy](https://img.shields.io/badge/accuracy-92.62%25-success)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-yellow.svg)](LICENSE)
+
+</div>
 
 ## Table of Contents
 

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" role="img" aria-label="llama3-emotion-lora — six-class emotion text classification with Llama3-8B, LoRA and FlashAttention; 92.62% accuracy, beating BERT and RoBERTa baselines">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="55%" stop-color="#4a044e"/>
+      <stop offset="100%" stop-color="#a21caf"/>
+    </linearGradient>
+    <clipPath id="bgclip">
+      <rect x="0" y="0" width="880" height="250" rx="16"/>
+    </clipPath>
+  </defs>
+
+  <rect x="0" y="0" width="880" height="250" rx="16" fill="url(#bg)"/>
+  <g clip-path="url(#bgclip)">
+    <circle cx="790" cy="0" r="190" fill="#e879f9" opacity="0.08"/>
+    <circle cx="350" cy="265" r="150" fill="#f0abfc" opacity="0.05"/>
+  </g>
+
+  <!-- ===== left column: brand ===== -->
+  <text x="40" y="82" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="30" font-weight="800" fill="#ffffff">llama3-emotion-lora</text>
+  <rect x="42" y="94" width="64" height="3" rx="1.5" fill="#e879f9" opacity="0.9"/>
+  <text x="40" y="124" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="13.5" fill="#cbd5e1">joy &#183; sadness &#183; anger &#183; fear &#183; love &#183; surprise</text>
+
+  <!-- method chips -->
+  <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="12" text-anchor="middle">
+    <rect x="40" y="140" width="80" height="24" rx="12" fill="#34d399" fill-opacity="0.12" stroke="#34d399" stroke-opacity="0.65"/>
+    <text x="80" y="156" fill="#6ee7b7">Llama3-8B</text>
+    <rect x="128" y="140" width="50" height="24" rx="12" fill="#60a5fa" fill-opacity="0.12" stroke="#60a5fa" stroke-opacity="0.65"/>
+    <text x="153" y="156" fill="#93c5fd">LoRA</text>
+    <rect x="186" y="140" width="78" height="24" rx="12" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.65"/>
+    <text x="225" y="156" fill="#fde68a">FlashAttn</text>
+  </g>
+
+  <!-- result pill -->
+  <rect x="40" y="178" width="216" height="28" rx="14" fill="#e879f9" fill-opacity="0.10" stroke="#e879f9" stroke-opacity="0.55"/>
+  <text x="54" y="196" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="12.5" fill="#f0abfc">92.62% &#183; beats BERT &amp; RoBERTa</text>
+
+  <!-- cli pill -->
+  <rect x="40" y="214" width="196" height="26" rx="13" fill="#ffffff" fill-opacity="0.07" stroke="#ffffff" stroke-opacity="0.18"/>
+  <text x="54" y="231" font-family="ui-monospace, SFMono-Regular, Consolas, 'Courier New', monospace" font-size="12.5" fill="#e2e8f0">$ llamafactory-cli train</text>
+
+  <!-- ===== card 1: instruction fine-tuning ===== -->
+  <g>
+    <rect x="350" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="380" cy="62" r="16" fill="#38bdf8" fill-opacity="0.14" stroke="#38bdf8" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <rect x="374" y="53" width="12" height="17" rx="2"/>
+      <line x1="377" y1="59" x2="383" y2="59"/>
+      <line x1="377" y1="64" x2="383" y2="64"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="366" y="102" font-size="14" font-weight="700" fill="#f1f5f9">Instruction</text>
+      <text x="366" y="120" font-size="14" font-weight="700" fill="#f1f5f9">fine-tuning</text>
+      <text x="366" y="142" font-size="11.5" fill="#94a3b8">emotion labels as</text>
+      <text x="366" y="158" font-size="11.5" fill="#94a3b8">generation targets</text>
+      <text x="366" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">LoRA r=8, fp16,</text>
+      <text x="366" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">FlashAttention-2</text>
+    </g>
+  </g>
+
+  <!-- ===== card 2: built on LLaMA-Factory ===== -->
+  <g>
+    <rect x="520" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="550" cy="62" r="16" fill="#34d399" fill-opacity="0.14" stroke="#34d399" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#34d399" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <rect x="543" y="57" width="14" height="11" rx="2"/>
+      <line x1="550" y1="57" x2="550" y2="50"/>
+      <path d="M 547 53 L 550 50 L 553 53"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="536" y="102" font-size="14" font-weight="700" fill="#f1f5f9">Built on</text>
+      <text x="536" y="120" font-size="14" font-weight="700" fill="#f1f5f9">LLaMA-Factory</text>
+      <text x="536" y="142" font-size="11.5" fill="#94a3b8">pip dependency &#8212; one</text>
+      <text x="536" y="158" font-size="11.5" fill="#94a3b8">yaml reproduces it</text>
+      <text x="536" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">no vendored code,</text>
+      <text x="536" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">Apache-2.0 credited</text>
+    </g>
+  </g>
+
+  <!-- ===== card 3: beats BERT baselines ===== -->
+  <g>
+    <rect x="690" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="720" cy="62" r="16" fill="#a78bfa" fill-opacity="0.14" stroke="#a78bfa" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#a78bfa" stroke-width="1.8" stroke-linecap="round">
+      <line x1="714" y1="68" x2="714" y2="62"/>
+      <line x1="720" y1="68" x2="720" y2="57"/>
+      <line x1="726" y1="68" x2="726" y2="52"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="706" y="102" font-size="14" font-weight="700" fill="#f1f5f9">Beats BERT</text>
+      <text x="706" y="120" font-size="14" font-weight="700" fill="#f1f5f9">baselines</text>
+      <text x="706" y="142" font-size="11.5" fill="#94a3b8">BERT &amp; RoBERTa,</text>
+      <text x="706" y="158" font-size="11.5" fill="#94a3b8">base and large</text>
+      <text x="706" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">92.62% vs 91.89%</text>
+      <text x="706" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">(RoBERTa-Large)</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Same masthead treatment as the rest of the portfolio: self-contained SVG banner (`docs/banner.svg`, fuchsia palette) — wordmark, the six emotion classes as the tagline, `Llama3-8B / LoRA / FlashAttn` chips, *92.62% · beats BERT & RoBERTa* pill, `llamafactory-cli train` hint, and three feature cards (instruction fine-tuning · built on LLaMA-Factory as a pip dependency, Apache-2.0 credited · beats BERT baselines, 92.62% vs 91.89% RoBERTa-Large).

This README previously had no badges at all — the masthead adds model / built-on / accuracy / license badges. Layout verified by rasterizing the SVG with headless Edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)